### PR TITLE
Fix universal_robot version name

### DIFF
--- a/ur.rosinstall
+++ b/ur.rosinstall
@@ -1,7 +1,7 @@
 - git:
   uri: https://github.com/fmauch/universal_robot.git
   local-name: fmauch_universal_robot
-  version: calibration-devel
+  version: calibration_devel
 - git:
   uri: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
   local-name: universal_robots_ros_driver


### PR DESCRIPTION
Branch name is calibration_devel instead of calibration-devel: https://github.com/fmauch/universal_robot/tree/calibration_devel